### PR TITLE
:bug: Random state handling fix

### DIFF
--- a/src/chemtorch/components/data_pipeline/data_splitter/data_splitter_base.py
+++ b/src/chemtorch/components/data_pipeline/data_splitter/data_splitter_base.py
@@ -49,7 +49,12 @@ class DataSplitterBase(ABC):
         if df.empty:
             raise ValueError("Input DataFrame is empty")
 
+        # NOTE: The random state has to be restored so subsequent operations like data shuffling
+        # in the data loader get the same RNG sequence as if no splitting had occurred. This is
+        # needed for reproducibility when using IndexSplitter on the saved indices.
+        np_state = np.random.get_state()
         indices = self._split(df)
+        np.random.set_state(np_state)
 
         self._save_split(indices)
         return DataSplit(


### PR DESCRIPTION
This pull request adds a reproducibility safeguard to the data splitting process in the `DataSplitterBase` class. The change ensures that the random number generator (RNG) state is preserved when splitting a DataFrame, so that subsequent random operations (such as shuffling) behave consistently, even when using split indices.

Reproducibility enhancement:

* In `data_splitter_base.py`, the RNG state is saved before splitting and restored afterwards, ensuring consistent random behavior for downstream operations that depend on the RNG sequence.