### PR TITLE
Bugfix/prediction saving

### DIFF
--- a/chemtorch_cli.py
+++ b/chemtorch_cli.py
@@ -1,9 +1,10 @@
 import logging
 import os
 from pathlib import Path
-from typing import List, cast
+from typing import Any, List, cast, Callable, Optional
 
 import hydra
+import pandas as pd
 import torch
 import lightning as L
 import wandb
@@ -12,43 +13,21 @@ from omegaconf import DictConfig, OmegaConf
 from chemtorch.core.data_module import DataModule, Stage
 from chemtorch.utils.cli import cli_chemtorch_logo
 from chemtorch.utils.hydra import safe_instantiate
-from chemtorch.utils.misc import save_predictions
-
-OmegaConf.register_new_resolver("eval", eval)
+from chemtorch.utils.misc import handle_prediction_saving
 
 ROOT_DIR = Path(__file__).parent
 
-
-def _get_prediction_save_path(dataset_key: str, cfg: DictConfig) -> str:
-    """
-    Get the appropriate save path for predictions based on configuration and dataset key.
-    
-    Args:
-        dataset_key: The dataset split key ("train", "val", "test", or "predict")
-        cfg: The configuration object
-    
-    Returns:
-        str: The file path where predictions should be saved
-    
-    Logic:
-        - If predictions_save_dir is set: use {predictions_save_dir}/{dataset_key}_preds.csv
-        - If predictions_save_path is set (single task scenario): use predictions_save_path directly
-        - Otherwise: raise error (user must specify one of the two)
-    """
-    if cfg.predictions_save_dir:
-        return f"{cfg.predictions_save_dir}/{dataset_key}_preds.csv"
-    elif cfg.predictions_save_path:
-        return cfg.predictions_save_path
-    else:
-        raise ValueError(
-            f"Cannot determine save path for {dataset_key} predictions. "
-            f"For single tasks, specify 'predictions_save_path'. "
-            f"For multiple tasks, specify 'predictions_save_dir' and 'save_predictions_for'."
-        )
+OmegaConf.register_new_resolver("eval", eval)
 
 @hydra.main(version_base=None, config_path="conf", config_name="base")
 def main(cfg: DictConfig):
     cli_chemtorch_logo()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s: %(message)s'
+    )
+    
     # config mutable
     OmegaConf.set_struct(cfg, False)
 
@@ -133,10 +112,10 @@ def main(cfg: DictConfig):
             stages.append("test")
         if "predict" in cfg.tasks:
             stages.append("predict")
-        for single_dataset_key in stages:
-            precompute_time = data_module.get_dataset_property(single_dataset_key, "precompute_time")
+        for dataset_key in stages:
+            precompute_time = data_module.get_dataset_property(dataset_key, "precompute_time")
             wandb.log(
-                {f"{single_dataset_key}_precompute_time": precompute_time},
+                {f"{dataset_key}_precompute_time": precompute_time},
                 commit=False,
             )
 
@@ -201,7 +180,6 @@ def main(cfg: DictConfig):
         # model after trainer.fit() for validate, test, predict by passing ckpt_path=None
         ckpt_for_inference = None
 
-    
     if "validate" in cfg.tasks:
         trainer.validate(routine, datamodule=data_module, ckpt_path=ckpt_for_inference)
 
@@ -212,93 +190,29 @@ def main(cfg: DictConfig):
         raise ValueError("Set `predictions_save_path` in the config to save the predictions.")
 
     ###### INFERENCE AND PREDICTION SAVING #####################################
-    # Normalize save_predictions_for to always be a list if provided
-    if cfg.save_predictions_for is not None:
-        if isinstance(cfg.save_predictions_for, str):
-            cfg.save_predictions_for = [cfg.save_predictions_for]
+    # Create closures to encapsulate the prediction generation logic
+    def get_preds_func(dataset_key: str) -> List[Any]:
+        stage_key = cast(Stage, dataset_key)
+        dataloader = data_module.make_dataloader(stage_key)
+        preds = trainer.predict(routine, ckpt_path=ckpt_for_inference, dataloaders=dataloader)
+        return preds if preds else []
     
-    # Determine which predictions to save
-    save_predictions_for = []
-    
-    # Validate configuration according to the rules
-    single_tasks = [task for task in ["predict", "validate", "test"] if task in cfg.tasks]
-    has_fit_or_multiple_tasks = "fit" in cfg.tasks or len(cfg.tasks) > 1
-    
-    # Handle gracefully: if save_predictions_for specified but no paths, just warn and skip
-    skip_prediction_saving = cfg.save_predictions_for and not cfg.predictions_save_dir and not cfg.predictions_save_path
-    if skip_prediction_saving:
-        logging.warning("'save_predictions_for' specified but no 'predictions_save_dir' or 'predictions_save_path' given. Skipping prediction saving.")
-    
-    elif has_fit_or_multiple_tasks and cfg.predictions_save_path and not cfg.save_predictions_for:
-        raise ValueError(
-            "For fit tasks or multiple tasks, you must specify 'save_predictions_for' to indicate "
-            "which datasets to save predictions for, and use 'predictions_save_dir' instead of 'predictions_save_path'."
-        )
-    
-    elif cfg.save_predictions_for and len(cfg.save_predictions_for) > 1 and cfg.predictions_save_path:
-        raise ValueError(
-            "Cannot use 'predictions_save_path' when saving predictions for multiple datasets. "
-            "Use 'predictions_save_dir' instead."
-        )
-    
-    # Determine save_predictions_for list (only if we're not skipping)
-    if not skip_prediction_saving:
-        # For single task scenarios (predict, validate, test), use predictions_save_path
-        if len(single_tasks) == 1 and len(cfg.tasks) == 1 and not cfg.save_predictions_for and cfg.predictions_save_path:
-            single_dataset_key = single_tasks[0] if single_tasks[0] != "validate" else "val"
-            save_predictions_for = [single_dataset_key]
+    def get_reference_df_func(dataset_key: str) -> pd.DataFrame:
+        stage_key = cast(Stage, dataset_key)
+        dataset = data_module.get_dataset(stage_key)
+        return dataset.dataframe.copy()
 
-        # For multi-task scenarios or explicit save_predictions_for, use that list
-        elif cfg.save_predictions_for:
-            if "all" in cfg.save_predictions_for:
-                if len(cfg.save_predictions_for) > 1:
-                    raise ValueError("When using 'all' in save_predictions_for, it should be the only item in the list.")
-                save_predictions_for = ["train", "val", "test", "predict"]
-            else:
-                save_predictions_for = cfg.save_predictions_for
-        
-    # Save predictions if requested
-    if save_predictions_for:
-        # Final validation before saving
-        if len(save_predictions_for) > 1 and cfg.predictions_save_path:
-            raise ValueError(
-                f"Cannot save predictions for multiple datasets ({save_predictions_for}) "
-                f"to a single file ({cfg.predictions_save_path}). Use 'predictions_save_dir' instead."
-            )
-        
-        if not cfg.predictions_save_dir and not cfg.predictions_save_path:
-            raise ValueError(
-                "Must specify either 'predictions_save_dir' or 'predictions_save_path' to save predictions."
-            )
-        
-        for single_dataset_key in ["train", "val", "test", "predict"]:
-            if single_dataset_key in save_predictions_for:
-                print(f"Generating predictions for {single_dataset_key} set...")
+    handle_prediction_saving(
+        get_preds_func=get_preds_func,
+        get_reference_df_func=get_reference_df_func,
+        predictions_save_dir=cfg.predictions_save_dir,
+        predictions_save_path=cfg.predictions_save_path,
+        save_predictions_for=cfg.save_predictions_for,
+        tasks=cfg.tasks,
+        log_func=wandb.log if cfg.log else None,
+        root_dir=ROOT_DIR,
+    )
 
-                # Cast to Stage type for type safety
-                stage_key = cast(Stage, single_dataset_key)
-                dataloader = data_module.make_dataloader(stage_key)
-                dataset = data_module.get_dataset(stage_key)
-                
-                preds = trainer.predict(routine, ckpt_path=ckpt_for_inference, dataloaders=dataloader)
-
-                if preds:
-                    pred_df = dataset.dataframe.copy()
-                    save_path = _get_prediction_save_path(single_dataset_key, cfg)
-                    save_predictions(
-                        preds=preds,
-                        reference_df=pred_df,
-                        save_path=save_path,
-                        log_func=wandb.log if cfg.log else None,
-                        root_dir=ROOT_DIR,
-                    )
-        
-        # Validate that all requested dataset keys are valid
-        valid_keys = {"train", "val", "test", "predict", "all"}
-        if cfg.save_predictions_for:
-            invalid_keys = set(cfg.save_predictions_for) - valid_keys
-            if invalid_keys:
-                raise ValueError(f"Invalid dataset keys in save_predictions_for: {invalid_keys}. Must be one of {valid_keys}.")
 
     if cfg.log:
         wandb.finish()

--- a/chemtorch_cli.py
+++ b/chemtorch_cli.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import List, cast
@@ -210,6 +211,11 @@ def main(cfg: DictConfig):
         raise ValueError("Set `prediction_save_path` in the config if you want to save the predictions for predict task.")
 
     ###### INFERENCE AND PREDICTION SAVING #####################################
+    # Normalize save_predictions_for to always be a list if provided
+    if cfg.save_predictions_for is not None:
+        if isinstance(cfg.save_predictions_for, str):
+            cfg.save_predictions_for = [cfg.save_predictions_for]
+    
     # Determine which predictions to save
     save_predictions_for = []
     
@@ -220,7 +226,7 @@ def main(cfg: DictConfig):
     # Handle gracefully: if save_predictions_for specified but no paths, just warn and skip
     skip_prediction_saving = cfg.save_predictions_for and not cfg.predictions_save_dir and not cfg.prediction_save_path
     if skip_prediction_saving:
-        print("WARNING: 'save_predictions_for' specified but no 'predictions_save_dir' or 'prediction_save_path' given. Skipping prediction saving.")
+        logging.warning("'save_predictions_for' specified but no 'predictions_save_dir' or 'prediction_save_path' given. Skipping prediction saving.")
     
     elif has_fit_or_multiple_tasks and cfg.prediction_save_path and not cfg.save_predictions_for:
         raise ValueError(

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -26,7 +26,7 @@ ckpt_path: null
 # Specify a single save path if only a single partition is instantiated, 
 # i.e. the single task it either 'predict', 'validate', or 'test'). If null, no
 # predictions will be saved.
-prediction_save_path: null
+predictions_save_path: null
 # Specify a directory path to which the predictions will be saved and for 
 # which partitions to save predictions if multiple partitions are instantiated, 
 # during the run i.e. the task is 'fit' or tasks contain multiple tasks. If 

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -23,9 +23,20 @@ load_model: false
 ckpt_path: null
 
 # PREDICTION SAVING
-prediction_save_path: null  # For single task scenarios (predict, validate, or test only)
-predictions_save_dir: null  # For multi-task scenarios - directory where separate files will be saved
-save_predictions_for: null  # List of datasets: ["train", "val", "test", "predict"] or ["all"] for all datasets
+# Specify a single save path if only a single partition is instantiated, 
+# i.e. the single task it either 'predict', 'validate', or 'test'). If null, no
+# predictions will be saved.
+prediction_save_path: null
+# Specify a directory path to which the predictions will be saved and for 
+# which partitions to save predictions if multiple partitions are instantiated, 
+# during the run i.e. the task is 'fit' or tasks contain multiple tasks. If 
+# null, no predictions will be saved.
+predictions_save_dir: null  
+# One of "train", "val", "test", "predict" or "all" for all datasets, or a list
+# of any of these to specify for which datasets to save predictions. Can be 
+# specified as a single string (e.g., "train") or as a list (e.g., ["train", "val"]).
+# If null, no predictions will be saved.
+save_predictions_for: null
 
 # Disable Hydra's automatic logging behavior since WandB is used for logging.
 hydra:

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -22,8 +22,10 @@ runtime_args_from_dataset: null
 load_model: false
 ckpt_path: null
 
-# PREDICTION
-prediction_save_path: null
+# PREDICTION SAVING
+prediction_save_path: null  # For single task scenarios (predict, validate, or test only)
+predictions_save_dir: null  # For multi-task scenarios - directory where separate files will be saved
+save_predictions_for: null  # List of datasets: ["train", "val", "test", "predict"] or ["all"] for all datasets
 
 # Disable Hydra's automatic logging behavior since WandB is used for logging.
 hydra:

--- a/conf/experiment/3d_graph.yaml
+++ b/conf/experiment/3d_graph.yaml
@@ -3,10 +3,10 @@ defaults:
   - /trainer: basic_trainer
   - /data_pipeline: rdb7_fwd_xyz
   - /dataset: graph
-  - /dataset/representation: rtsp_3d_graph
   - /dataloader: pyg_dataloader
   - /model: dimenetplusplus
   - /routine: regression
+  - override /dataset/representation: rtsp_3d_graph
   - _self_
 
 # LOGGING (Weight and Biases)

--- a/conf/experiment/graph.yaml
+++ b/conf/experiment/graph.yaml
@@ -35,4 +35,4 @@ load_model: false
 ckpt_path: null
 
 # PREDICTION
-prediction_save_path: prediction/${project_name}/.../predictions.csv
+predictions_save_path: prediction/${project_name}/.../predictions.csv

--- a/conf/experiment/graph.yaml
+++ b/conf/experiment/graph.yaml
@@ -33,6 +33,3 @@ runtime_args_from_dataset:
 # MODEL LOADING
 load_model: false
 ckpt_path: null
-
-# PREDICTION
-predictions_save_path: prediction/${project_name}/.../predictions.csv

--- a/conf/experiment/opi_tutorial/inference.yaml
+++ b/conf/experiment/opi_tutorial/inference.yaml
@@ -32,7 +32,7 @@ load_model: true
 ckpt_path: "lightning_logs/rgd1/dmpnn/seed_0_2025-08-13_10-28-40/checkpoints/epoch=58-step=15989.ckpt"
 
 # Save predictions
-prediction_save_path: "../predictions.csv"
+predictions_save_path: "../predictions.csv"
 
 
 # Don't create a new standardizer (the standardizer of the training set is loaded from the checkpoint)

--- a/src/chemtorch/core/data_module.py
+++ b/src/chemtorch/core/data_module.py
@@ -47,7 +47,7 @@ class DataModule(L.LightningDataModule):
         Raises:
             AttributeError: If the property does not exist in the train dataset or is not a @property.
         """
-        dataset = self._get_dataset(key)
+        dataset = self.get_dataset(key)
         # Check if the attribute is a property of the dataset's class
         if hasattr(type(dataset), property) and isinstance(
             getattr(type(dataset), property), builtins.property
@@ -57,21 +57,57 @@ class DataModule(L.LightningDataModule):
             raise AttributeError(
                 f"Dataset does not have a property '{property}' (must be a @property)."
             )
+        
+    def get_dataset(self, key: Stage) -> DatasetBase:
+        """
+        Retrieve the dataset for the specified key.
+
+        Args:
+            key (str): The key for which to retrieve the dataset ('train', 'val', 'test', 'predict').
+
+        Returns:
+            Any: The dataset corresponding to the specified key.
+
+        Raises:
+            ValueError: If the dataset for the specified key is not initialized.
+        """
+        dataset = getattr(self, f"{key}_dataset", None)
+        if dataset is None:
+            raise ValueError(f"{key.capitalize()} dataset is not initialized.")
+        return dataset
+
+    def make_dataloader(self, key: Stage) -> DataLoader:
+        """
+        Create a dataloader for the specified key.
+
+        Args:
+            key (str): The key for which to create the dataloader ('train', 'val', 'test', 'predict').
+
+        Returns:
+            DataLoader: The created dataloader.
+
+        Raises:
+            ValueError: If the dataset for the specified key is not initialized.
+        """
+        return self.dataloader_factory(
+            dataset=self.get_dataset(key), 
+            shuffle=(key == "train")
+        )
 
     ########## Lightning DataModule Methods ##############################################
     # TODO: Optionally, add `prepare_data()` to preprocess datasets and save preprocesssed data to disc.
     # TODO: Optionally, move dataset initialization to `setup()` method to allow for lazy loading.
     def train_dataloader(self):
-        return self._make_dataloader_or_raise("train")
+        return self.make_dataloader("train")
 
     def val_dataloader(self):
-        return self._make_dataloader_or_raise("val")
+        return self.make_dataloader("val")
 
     def test_dataloader(self):
-        return self._make_dataloader_or_raise("test")
+        return self.make_dataloader("test")
 
     def predict_dataloader(self):
-        return self._make_dataloader_or_raise("predict")
+        return self.make_dataloader("predict")
 
     ########### Private Methods ##########################################################
     def _init_datasets(
@@ -104,39 +140,4 @@ class DataModule(L.LightningDataModule):
             raise TypeError(
                 "Data pipeline must output either a DataSplit or a pandas DataFrame"
             )
-
-    def _get_dataset(self, key: Stage) -> DatasetBase:
-        """
-        Retrieve the dataset for the specified key.
-
-        Args:
-            key (str): The key for which to retrieve the dataset ('train', 'val', 'test', 'predict').
-
-        Returns:
-            Any: The dataset corresponding to the specified key.
-
-        Raises:
-            ValueError: If the dataset for the specified key is not initialized.
-        """
-        dataset = getattr(self, f"{key}_dataset", None)
-        if dataset is None:
-            raise ValueError(f"{key.capitalize()} dataset is not initialized.")
-        return dataset
-
-    def _make_dataloader_or_raise(self, key: Stage) -> DataLoader:
-        """
-        Create a dataloader for the specified key or raise an error if the dataset is not initialized.
-
-        Args:
-            key (str): The key for which to create the dataloader ('train', 'val', 'test', 'predict').
-
-        Returns:
-            DataLoader: The created dataloader.
-
-        Raises:
-            ValueError: If the dataset for the specified key is not initialized.
-        """
-        return self.dataloader_factory(
-            dataset=self._get_dataset(key), 
-            shuffle=(key == "train")
-        )
+            

--- a/src/chemtorch/utils/__init__.py
+++ b/src/chemtorch/utils/__init__.py
@@ -3,12 +3,4 @@ from .callable_compose import CallableCompose
 from .decorators.enforce_base_init import enforce_base_init
 from .standardizer import Standardizer
 from .types import DataSplit
-from .misc import (
-    save_model, 
-    load_model, 
-    save_standardizer, 
-    load_standardizer, 
-    get_generator, 
-    set_seed, 
-    check_early_stopping
-)
+from .misc import handle_prediction_saving

--- a/src/chemtorch/utils/misc.py
+++ b/src/chemtorch/utils/misc.py
@@ -35,7 +35,7 @@ def get_generator(seed: int) -> torch.Generator:
 def save_predictions(
     preds: List[Any],
     reference_df: pd.DataFrame,
-    save_path: Optional[Union[str, Path]] = None,
+    save_path: Optional[Union[str, Path]],
     log_func: Optional[Callable[..., Any]] = None,
     root_dir: Optional[Path] = None
 ) -> Optional[pd.DataFrame]:
@@ -56,6 +56,9 @@ def save_predictions(
     if preds is None or reference_df is None:
         return
     
+    if save_path is None:
+        return
+
     # Convert tensor predictions to numpy values
     # preds is a list of batches, need to flatten all predictions
     pred_values = []
@@ -92,23 +95,21 @@ def save_predictions(
     result_df = reference_df.copy()
     result_df['prediction'] = pred_values
     
-    # Save to file if path provided
-    if save_path:
-        if root_dir:
-            output_path = root_dir / save_path
-        else:
-            output_path = Path(save_path)
-        
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        result_df.to_csv(output_path, index=False)
-        print(f"Predictions saved to: {output_path}")
-        
-        # Log results if logging function provided
-        if log_func:
-            log_func({
-                "predictions_file": str(output_path),
-                "num_predictions": len(pred_values)
-            }, commit=False)
+    if root_dir:
+        output_path = root_dir / save_path
+    else:
+        output_path = Path(save_path)
+    
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    result_df.to_csv(output_path, index=False)
+    print(f"Predictions saved to: {output_path}")
+    
+    # Log results if logging function provided
+    if log_func:
+        log_func({
+            "predictions_file": str(output_path),
+            "num_predictions": len(pred_values)
+        }, commit=False)
 
 def set_seed(seed):
     """DEPRECATED"""

--- a/test/test_chemtorch/test_prediction_saving.py
+++ b/test/test_chemtorch/test_prediction_saving.py
@@ -1,0 +1,368 @@
+import os
+import tempfile
+from pathlib import Path
+from typing import List, Any
+from unittest.mock import Mock, call
+import pandas as pd
+import pytest
+import torch
+from omegaconf import ListConfig
+
+from chemtorch.utils.misc import handle_prediction_saving
+
+
+class TestHandlePredictionSaving:
+    """Test suite for the handle_prediction_saving function."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        # Create mock functions for predictions and reference data
+        self.mock_get_preds_func = Mock()
+        self.mock_get_reference_df_func = Mock()
+        self.mock_log_func = Mock()
+        
+        # Sample data
+        self.sample_preds = [torch.tensor([1.0, 2.0, 3.0])]
+        self.sample_df = pd.DataFrame({
+            'smiles': ['CCO', 'CCC', 'CCCC'],
+            'target': [0.1, 0.2, 0.3]
+        })
+        
+        # Configure mocks to return sample data
+        self.mock_get_preds_func.return_value = self.sample_preds
+        self.mock_get_reference_df_func.return_value = self.sample_df
+
+    def test_no_saving_when_no_save_paths(self):
+        """Test that no saving occurs when neither save_dir nor save_path is provided."""
+        handle_prediction_saving(
+            get_preds_func=self.mock_get_preds_func,
+            get_reference_df_func=self.mock_get_reference_df_func,
+            predictions_save_dir=None,
+            predictions_save_path=None,
+            save_predictions_for="test",
+            tasks=["test"]
+        )
+        
+        # Should not call the prediction functions
+        self.mock_get_preds_func.assert_not_called()
+        self.mock_get_reference_df_func.assert_not_called()
+
+    def test_warning_when_save_predictions_for_but_no_paths(self, caplog):
+        """Test warning is logged when save_predictions_for is specified but no paths given."""
+        handle_prediction_saving(
+            get_preds_func=self.mock_get_preds_func,
+            get_reference_df_func=self.mock_get_reference_df_func,
+            predictions_save_dir=None,
+            predictions_save_path=None,
+            save_predictions_for="test",
+            tasks=["test"]
+        )
+        
+        assert "'save_predictions_for' specified but no 'predictions_save_dir' or 'predictions_save_path' given" in caplog.text
+
+    def test_single_string_save_predictions_for(self):
+        """Test handling when save_predictions_for is a single string."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=None,
+                predictions_save_path=str(temp_path / "test_preds.csv"),
+                save_predictions_for="test",
+                tasks=["test"]
+            )
+            
+            # Should call functions for test dataset
+            self.mock_get_preds_func.assert_called_once_with("test")
+            self.mock_get_reference_df_func.assert_called_once_with("test")
+            
+            # Check file was created
+            assert (temp_path / "test_preds.csv").exists()
+
+    def test_list_save_predictions_for(self):
+        """Test handling when save_predictions_for is a list."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=str(temp_path),
+                predictions_save_path=None,
+                save_predictions_for=["test", "val"],
+                tasks=["fit", "test"]
+            )
+            
+            # Should call functions for both test and val datasets
+            expected_calls = [call("test"), call("val")]
+            self.mock_get_preds_func.assert_has_calls(expected_calls, any_order=True)
+            self.mock_get_reference_df_func.assert_has_calls(expected_calls, any_order=True)
+            
+            # Check files were created
+            assert (temp_path / "test_preds.csv").exists()
+            assert (temp_path / "val_preds.csv").exists()
+
+    def test_hydra_list_string_format(self):
+        """Test handling when Hydra passes a list as a string (e.g., '[test,val]')."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Test single item list
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=str(temp_path),
+                predictions_save_path=None,
+                save_predictions_for="[test]",
+                tasks=["test"]
+            )
+            
+            # Should call functions for test dataset
+            self.mock_get_preds_func.assert_called_with("test")
+            self.mock_get_reference_df_func.assert_called_with("test")
+            
+            # Check file was created
+            assert (temp_path / "test_preds.csv").exists()
+            
+            # Reset mocks for next test
+            self.mock_get_preds_func.reset_mock()
+            self.mock_get_reference_df_func.reset_mock()
+            
+            # Test multi-item list
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=str(temp_path / "multi"),
+                predictions_save_path=None,
+                save_predictions_for="[test, val]",
+                tasks=["fit", "test"]
+            )
+            
+            # Should call functions for both datasets
+            expected_calls = [call("test"), call("val")]
+            self.mock_get_preds_func.assert_has_calls(expected_calls, any_order=True)
+            self.mock_get_reference_df_func.assert_has_calls(expected_calls, any_order=True)
+
+    def test_omegaconf_listconfig_save_predictions_for(self):
+        """Test handling when save_predictions_for is an OmegaConf ListConfig."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create ListConfig (simulating what Hydra passes)
+            list_config = ListConfig(["test", "val"])
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=str(temp_path),
+                predictions_save_path=None,
+                save_predictions_for=list_config,
+                tasks=["fit", "test"]
+            )
+            
+            # Should call functions for both test and val datasets
+            expected_calls = [call("test"), call("val")]
+            self.mock_get_preds_func.assert_has_calls(expected_calls, any_order=True)
+            self.mock_get_reference_df_func.assert_has_calls(expected_calls, any_order=True)
+            
+            # Check files were created
+            assert (temp_path / "test_preds.csv").exists()
+            assert (temp_path / "val_preds.csv").exists()
+
+    def test_all_keyword_expands_to_available_partitions(self):
+        """Test that 'all' keyword expands to available partitions based on tasks."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=str(temp_path),
+                predictions_save_path=None,
+                save_predictions_for="all",
+                tasks=["fit", "test", "predict"]
+            )
+            
+            # Should call functions for train, val, test, predict (all available from tasks)
+            expected_calls = [call("train"), call("val"), call("test"), call("predict")]
+            self.mock_get_preds_func.assert_has_calls(expected_calls, any_order=True)
+            self.mock_get_reference_df_func.assert_has_calls(expected_calls, any_order=True)
+
+    def test_validate_task_maps_to_val_dataset(self):
+        """Test that 'validate' task correctly maps to 'val' dataset key."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=None,
+                predictions_save_path=str(temp_path / "val_preds.csv"),
+                save_predictions_for=None,  # Will use task
+                tasks=["validate"]
+            )
+            
+            # Should call functions for val dataset (not validate)
+            self.mock_get_preds_func.assert_called_once_with("val")
+            self.mock_get_reference_df_func.assert_called_once_with("val")
+
+    def test_single_partition_uses_predictions_save_path(self):
+        """Test that single partition scenarios use predictions_save_path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            custom_path = temp_path / "custom_predictions.csv"
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=str(temp_path),
+                predictions_save_path=str(custom_path),
+                save_predictions_for="test",
+                tasks=["test"]
+            )
+            
+            # Should use custom path, not default naming
+            assert custom_path.exists()
+            assert not (temp_path / "test_preds.csv").exists()
+
+    def test_multi_partition_uses_predictions_save_dir(self):
+        """Test that multi-partition scenarios use predictions_save_dir with default naming."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=str(temp_path),
+                predictions_save_path=str(temp_path / "custom.csv"),
+                save_predictions_for=["test", "val"],
+                tasks=["fit"]
+            )
+            
+            # Should use default naming pattern, not custom path
+            assert (temp_path / "test_preds.csv").exists()
+            assert (temp_path / "val_preds.csv").exists()
+            assert not (temp_path / "custom.csv").exists()
+
+    def test_invalid_save_predictions_for_value_raises_error(self):
+        """Test that invalid values in save_predictions_for raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid entries in 'save_predictions_for'"):
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir="/tmp",
+                predictions_save_path=None,
+                save_predictions_for=["invalid_key"],
+                tasks=["test"]
+            )
+
+    def test_invalid_save_predictions_for_type_raises_error(self):
+        """Test that invalid type for save_predictions_for raises ValueError."""
+        with pytest.raises(ValueError, match="'save_predictions_for' must be a string or list"):
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir="/tmp",
+                predictions_save_path=None,
+                save_predictions_for=123,  # Invalid type
+                tasks=["test"]
+            )
+
+    def test_multi_partition_without_save_dir_raises_error(self):
+        """Test that multi-partition scenarios without save_dir raise ValueError."""
+        with pytest.raises(ValueError, match="To save predictions for multiple partitions"):
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=None,
+                predictions_save_path="/tmp/test.csv",
+                save_predictions_for=["test", "val"],
+                tasks=["fit"]
+            )
+
+    def test_logging_function_called_when_provided(self):
+        """Test that log_func is called when predictions are saved."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=None,
+                predictions_save_path=str(temp_path / "test_preds.csv"),
+                save_predictions_for="test",
+                tasks=["test"],
+                log_func=self.mock_log_func
+            )
+            
+            # Should call log function
+            self.mock_log_func.assert_called_once()
+            call_args = self.mock_log_func.call_args[0][0]
+            assert "predictions_file" in call_args
+            assert "num_predictions" in call_args
+
+    def test_no_predictions_skips_saving(self):
+        """Test that when no predictions are returned, saving is skipped."""
+        # Configure mock to return empty predictions
+        self.mock_get_preds_func.return_value = []
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            save_path = temp_path / "test_preds.csv"
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=None,
+                predictions_save_path=str(save_path),
+                save_predictions_for="test",
+                tasks=["test"]
+            )
+            
+            # File should not be created
+            assert not save_path.exists()
+
+    def test_root_dir_path_resolution(self):
+        """Test that root_dir is properly used for path resolution."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root_path = Path(temp_dir)
+            relative_path = "predictions/test_preds.csv"
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=None,
+                predictions_save_path=relative_path,
+                save_predictions_for="test",
+                tasks=["test"],
+                root_dir=root_path
+            )
+            
+            # Should create file at root_dir/relative_path
+            expected_path = root_path / relative_path
+            assert expected_path.exists()
+
+    def test_predictions_saved_correctly_with_proper_content(self):
+        """Test that predictions are saved with correct content."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            save_path = temp_path / "test_preds.csv"
+            
+            handle_prediction_saving(
+                get_preds_func=self.mock_get_preds_func,
+                get_reference_df_func=self.mock_get_reference_df_func,
+                predictions_save_dir=None,
+                predictions_save_path=str(save_path),
+                save_predictions_for="test",
+                tasks=["test"]
+            )
+            
+            # Read saved file and verify content
+            saved_df = pd.read_csv(save_path)
+            assert len(saved_df) == 3
+            assert 'prediction' in saved_df.columns
+            assert 'smiles' in saved_df.columns
+            assert 'target' in saved_df.columns
+            assert saved_df['prediction'].tolist() == [1.0, 2.0, 3.0]


### PR DESCRIPTION
This pull request introduces a refactor and enhancement of the prediction saving workflow, making it more flexible and robust, especially for handling prediction and saving on multiple data partitions. It also improves the interface for dataset and dataloader access, clarifies configuration options, and adds better error handling and logging for predictions. The most important changes are grouped below:

**Prediction Saving Refactor and Improvements**
* Replaces the old `save_predictions` logic with a new `handle_prediction_saving` utility, allowing flexible saving of predictions for multiple partitions (train, val, test, predict), and supporting both single-file and per-partition directory saving, based on new config options. The logic now uses closures to retrieve predictions and reference dataframes for each partition, and raises errors if required config options are missing. (`chemtorch_cli.py`, `src/chemtorch/utils/misc.py`, `conf/base.yaml`, [[1]](diffhunk://#diff-e2bf4b872b77a167b87cc77f60db9341a0abecdc24a0eb7a366dd69224cf9b6fR167-R216) [[2]](diffhunk://#diff-0e90091733e0ab428a158dccc1094931138817d75d1ec3bd9e5c2fc941e19d34L1-R22) [[3]](diffhunk://#diff-6f895193087b2b798035b09988205742bac2afd9829ef5695fe11954dbba1b93L25-R39)
* The CLI now requires `predictions_save_path` or `predictions_save_dir` to be set in the config for prediction saving, and provides clearer error messages if not set. (`chemtorch_cli.py`, [chemtorch_cli.pyR167-R216](diffhunk://#diff-e2bf4b872b77a167b87cc77f60db9341a0abecdc24a0eb7a366dd69224cf9b6fR167-R216))
* The configuration files are updated to support the new prediction saving options, with improved documentation and naming (`predictions_save_path`, `predictions_save_dir`, `save_predictions_for`). (`conf/base.yaml`, `conf/experiment/opi_tutorial/inference.yaml`, [[1]](diffhunk://#diff-6f895193087b2b798035b09988205742bac2afd9829ef5695fe11954dbba1b93L25-R39) [[2]](diffhunk://#diff-9797544269f511f43f23e7b7fe3fcd92f95fe4a250b8711b58d62889e4abf9bfL27-R35)
* The `save_predictions` function is improved to robustly flatten and concatenate batch predictions, handle various tensor/list formats, and raise errors if the number of predictions does not match the dataset size. Logging is now used instead of print statements. (`src/chemtorch/utils/misc.py`, [src/chemtorch/utils/misc.pyL58-R80](diffhunk://#diff-0e90091733e0ab428a158dccc1094931138817d75d1ec3bd9e5c2fc941e19d34L58-R80))

**DataModule Interface and Refactor**
* Introduces new public methods `get_dataset` and `make_dataloader` in `DataModule`, replacing the previous private `_get_dataset` and `_make_dataloader_or_raise` methods. This simplifies and standardizes dataset and dataloader access throughout the codebase. (`src/chemtorch/core/data_module.py`, [[1]](diffhunk://#diff-205dd792b14f26bda390ec291cd567e4e2afdf40202c68d102c4ae7c18a0e627L50-R50) [[2]](diffhunk://#diff-205dd792b14f26bda390ec291cd567e4e2afdf40202c68d102c4ae7c18a0e627R61-R110) [[3]](diffhunk://#diff-205dd792b14f26bda390ec291cd567e4e2afdf40202c68d102c4ae7c18a0e627L108-L142)
* Updates all internal usages and Lightning hooks to use the new `make_dataloader` and `get_dataset` methods. (`src/chemtorch/core/data_module.py`, [src/chemtorch/core/data_module.pyR61-R110](diffhunk://#diff-205dd792b14f26bda390ec291cd567e4e2afdf40202c68d102c4ae7c18a0e627R61-R110))

**Lightning Routine Prediction Step**
* Adds a robust `predict_step` implementation to `SupervisedRoutine` that can handle batches with or without targets, enabling prediction with any of train/val/test/predict dataloaders without errors. (`src/chemtorch/core/routine/supervised_routine.py`, [src/chemtorch/core/routine/supervised_routine.pyR225-R255](diffhunk://#diff-76c4c8998751367329d15a4146f3456b9c6976357fddd304eaf1aed99d295952R225-R255))

**General Codebase Cleanup**
* Removes deprecated and unused utility functions from `misc.py` and cleans up imports in utility modules. (`src/chemtorch/utils/__init__.py`, `src/chemtorch/utils/misc.py`, [[1]](diffhunk://#diff-e0450db83ac75270d993f206a147fff08eed329ec7449edb19e9c86196b23209L6-R6) [[2]](diffhunk://#diff-0e90091733e0ab428a158dccc1094931138817d75d1ec3bd9e5c2fc941e19d34L1-R22)

**Configuration and Example Updates**
* Updates experiment configuration files to use the new prediction saving interface and corrects data paths for clarity in tutorials. (`conf/experiment/opi_tutorial/inference.yaml`, `conf/experiment/opi_tutorial/training.yaml`, [[1]](diffhunk://#diff-9797544269f511f43f23e7b7fe3fcd92f95fe4a250b8711b58d62889e4abf9bfL27-R35) [[2]](diffhunk://#diff-d478ffd177e146c3210fe449b12b3452f6ec21f30b0d685fc7248093265a1ebaL28-R28)

These changes collectively make the prediction saving process more robust, configurable, and user-friendly, while simplifying the internal data access patterns and improving error handling and logging throughout the workflow.