### PR TITLE
Bugfix automatic determination of num_workers for data loader

### DIFF
--- a/conf/data_module/dataloader_factory/pyg_dataloader.yaml
+++ b/conf/data_module/dataloader_factory/pyg_dataloader.yaml
@@ -2,6 +2,6 @@ _target_: torch_geometric.loader.DataLoader
 _partial_: true
 
 batch_size: 50
-# cap to avoid oversubscription and leave 1 core for the main process
-num_workers: ${eval:"max(0, min(int(os.getenv('SLURM_CPUS_PER_TASK', 4)), (os.cpu_count() or 1)) - 1)"}
+num_workers: ${eval:"__import__('importlib').import_module('src.chemtorch.utils.hydra').get_num_workers()"}
 pin_memory: true
+# persistent_workers: true

--- a/conf/data_module/dataloader_factory/torch_dataloader.yaml
+++ b/conf/data_module/dataloader_factory/torch_dataloader.yaml
@@ -2,6 +2,6 @@ _target_: torch.utils.data.DataLoader
 _partial_: true
 
 batch_size: 50
-# cap to avoid oversubscription and leave 1 core for the main process
-num_workers: ${eval:"max(0, min(int(os.getenv('SLURM_CPUS_PER_TASK', 4)), (os.cpu_count() or 1)) - 1)"}
+num_workers: ${eval:"__import__('importlib').import_module('src.chemtorch.utils.hydra').get_num_workers()"}
 pin_memory: true
+# persistent_workers: true


### PR DESCRIPTION
This pull request updates how the number of worker processes for PyTorch DataLoaders is determined, making the configuration more robust and platform-aware. The main change is replacing the previous inline logic for setting `num_workers` with a new utility function, which improves maintainability and handles edge cases, especially for macOS and SLURM environments.

**DataLoader worker configuration improvements:**

* Introduced a new function `get_num_workers` in `src.chemtorch.utils.hydra.py` to encapsulate logic for safely determining the number of DataLoader workers, taking into account SLURM environment variables, CPU count, and platform-specific issues (e.g., defaults to 0 workers on macOS unless overridden).
* Updated both `conf/data_module/dataloader_factory/pyg_dataloader.yaml` and `conf/data_module/dataloader_factory/torch_dataloader.yaml` to use the new `get_num_workers()` function for the `num_workers` parameter, replacing the previous inline expression. [[1]](diffhunk://#diff-02128853f42fbfba0e99ec9a75859a8261c93c6a78ff033a9cbb3bb5a688a8efL5-R7) [[2]](diffhunk://#diff-098f3c5f69bea075e104590f25da1f093d7ca9a4db65e1a4ef9dc04d60351ba6L5-R7)